### PR TITLE
Add parse multiple empty newlines in message

### DIFF
--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -40,7 +40,7 @@ class Parser
 
     private function parseMessage($message)
     {
-        $lines = explode(self::EOL, $message);
+        $lines = array_filter(explode(self::EOL, $message));
         $last  = count($lines) - 1;
         $fields = array();
 

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -32,7 +32,10 @@ class Parser
             $message = substr($this->buffer, 0, $pos);
             $this->buffer = (string)substr($this->buffer, $pos + self::LEOM);
 
-            $messages []= $this->parseMessage($message);
+            $parsed = $this->parseMessage($message);
+            if (!empty($parsed->getFields())) {
+                $messages []= $parsed;
+            }
         }
 
         return $messages;

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -153,4 +153,19 @@ class ParserTest extends TestCase
         $this->assertInstanceOf('Clue\React\Ami\Protocol\Response', $first);
         $this->assertEquals('', $first->getFieldValue('Response'));
     }
+
+    public function testParsingEmptyLines()
+    {
+        $parser = new Parser();
+        $this->assertEquals(array(), $parser->push("Asterisk Call Manager/1.3\r\n"));
+
+        $ret = $parser->push("First: 1\r\n\r\nSecond: 2\r\n\r\n\r\nThird: 3\r\n\r\n\r\n\r\nFourth: 4\r\n\r\n");
+        $this->assertCount(4, $ret);
+
+        $last = $ret[count($ret) - 1];
+        /* @var $last Clue\React\Ami\Protocol\Response */
+
+        $this->assertInstanceOf('Clue\React\Ami\Protocol\Response', $last);
+        $this->assertEquals('4', $last->getFieldValue('Fourth'));
+    }
 }


### PR DESCRIPTION
Related to #30 

### Environment:
Asterisk 16.6.1 running on Ubuntu 18.04

### Steps to reproduce:
* Configure an AMI user in manager.conf with `read = all` and `write = all`
* Listen to AMI events
* Call an extension in the dialplan that triggers an AGI script that then uses the Dial application

### Description:
Yesterday I ran into an issue causing the exception: `Parse error, no colon in line "" found`.

While connected to AMI `telnet 127.0.0.1 5038`, I noticed the following Event output:
```bash
Event: DeviceStateChange
Privilege: call,all
Device: PJSIP/2101
State: RINGING

Event: TestEvent
Privilege: reporting,all
Type: StateChange
State: RINGING_INBAND
AppFile: channel.c
AppFunction: indicate_data_internal
AppLine: 4562
Channel: PJSIP/2102-00000046


Event: VarSet
Privilege: dialplan,all
Channel: PJSIP/2102-00000046
ChannelState: 6
ChannelStateDesc: Up
CallerIDNum: 2102
CallerIDName: Test 2102
ConnectedLineNum: 9999
ConnectedLineName: <unknown>
Language: en
AccountCode: 
Context: demo
Exten: 9999
Priority: 5
Uniqueid: 1571783545.531
Linkedid: 1571783545.531
Variable: RINGTIME
Value: 0
```

There is an extra blank line after the `TestEvent` Event that gets passed to the `parseMessage` method as the first line of the next `VarSet` Event that throws an error because the line does not contain a colon.  I suspect the extra line is either coming from the end of the `TestEvent` or beginning of the `VarSet` Event in asterisk's code.

This change will remove any empty lines in a message before the lines are parsed.