### PR TITLE
Run tests on PHPUnit 9 and update PHPUnit configuration schema for PHPUnit 9.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.travis.yml export-ignore
 /examples/ export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 # lock distro so new future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
@@ -24,9 +24,10 @@ install:
   - sudo apt-get --no-install-recommends -qq install -y asterisk
   - sudo cp tests/username.conf /etc/asterisk/manager.d/username.conf
   - sudo /etc/init.d/asterisk reload
-  - composer install --no-interaction
+  - composer install
 
 script:
   - sudo /etc/init.d/asterisk status || sudo /etc/init.d/asterisk start
   - sudo /etc/init.d/asterisk status || sleep 2
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "clue/block-react": "^1.2",
-        "phpunit/phpunit": "^7.0 || ^6.0 || ^5.0 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "autoload": {
         "psr-4": { "Clue\\React\\Ami\\": "src/" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="Asterisk AMI Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Asterisk AMI Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/ActionSenderTest.php
+++ b/tests/ActionSenderTest.php
@@ -53,7 +53,13 @@ class ActionSenderTest extends TestCase
     {
         $stream = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->getMock();
 
-        $client = $this->getMockBuilder('Clue\React\Ami\Client')->setMethods(array('createAction'))->setConstructorArgs(array($stream))->getMock();
+        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'onlyMethods')) {
+            // PHPUnit 9+
+            $client = $this->getMockBuilder('Clue\React\Ami\Client')->onlyMethods(array('createAction'))->setConstructorArgs(array($stream))->getMock();
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 8
+            $client = $this->getMockBuilder('Clue\React\Ami\Client')->setMethods(array('createAction'))->setConstructorArgs(array($stream))->getMock();
+        }
 
         return $client;
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -45,6 +45,12 @@ class ClientTest extends TestCase
 
     private function createStreamMock()
     {
-        return $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(array('write', 'close'))->getMock();
+        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'onlyMethods')) {
+            // PHPUnit 9+
+            return $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->onlyMethods(array('write', 'close'))->getMock();
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 8
+            return $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->setMethods(array('write', 'close'))->getMock();
+        }
     }
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -11,7 +11,10 @@ class FactoryTest extends TestCase
     private $tcp;
     private $factory;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpFactory()
     {
         $this->loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $this->tcp = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -13,13 +13,19 @@ class FunctionalTest extends TestCase
     private static $address = false;
     private static $loop;
 
-    public static function setUpBeforeClass()
+    /**
+     * @beforeClass
+     */
+    public static function setUpLoopBeforeClass()
     {
         self::$address = getenv('LOGIN');
         self::$loop = \React\EventLoop\Factory::create();
     }
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpSkipTest()
     {
         if (self::$address === false) {
             $this->markTestSkipped('No ENV named LOGIN found. Please use "export LOGIN=\'user:pass@host\'.');
@@ -54,10 +60,10 @@ class FunctionalTest extends TestCase
     /**
      * @depends testConnection
      * @param Client $client
-     * @expectedException Exception
      */
     public function testInvalidCommandGetsRejected(Client $client)
     {
+        $this->setExpectedException('Exception');
         $this->waitFor($client->request($client->createAction('Invalid')));
     }
 
@@ -85,10 +91,10 @@ class FunctionalTest extends TestCase
     /**
      * @depends testActionSenderLogoffDisconnects
      * @param Client $client
-     * @expectedException Exception
      */
     public function testSendRejectedAfterClose(Client $client)
     {
+        $this->setExpectedException('Exception');
         $this->waitFor($client->request($client->createAction('Ping')));
     }
 

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -132,14 +132,12 @@ class ParserTest extends TestCase
         $this->assertEquals('Some message--END COMMAND--', $first->getFieldValue('Message'));
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function testParsingInvalidResponseFails()
     {
         $parser = new Parser();
         $this->assertEquals(array(), $parser->push("Asterisk Call Manager/1.3\r\n"));
 
+        $this->setExpectedException('UnexpectedValueException');
         $parser->push("invalid response\r\n\r\n");
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,6 +18,29 @@ class TestCase extends BaseTestCase
 
     protected function createCallableMock()
     {
-        return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
+            // PHPUnit 9+
+            return $this->getMockBuilder('stdClass')->addMethods(array('__invoke'))->getMock();
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 8
+            return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        }
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
     }
 }


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0beta2-cli php vendor/bin/phpunit
PHPUnit 9.4.0 by Sebastian Bergmann and contributors.

.........SSSSS.........................                           39 / 39 (100%)

Time: 00:00.026, Memory: 8.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 39, Assertions: 97, Skipped: 5.
```