### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ Once [installed](#install), you can use the following code to access your local
 Asterisk instance and issue some simple commands via AMI:
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$factory = new Clue\React\Ami\Factory($loop);
+$factory = new Clue\React\Ami\Factory();
 
 $factory->createClient('user:secret@localhost')->then(function (Clue\React\Ami\Client $client) {
     echo 'Client connected' . PHP_EOL;
@@ -91,8 +90,6 @@ $factory->createClient('user:secret@localhost')->then(function (Clue\React\Ami\C
         var_dump($response);
     });
 });
-
-$loop->run();
 ```
 
 See also the [examples](examples).
@@ -102,19 +99,23 @@ See also the [examples](examples).
 ### Factory
 
 The `Factory` is responsible for creating your [`Client`](#client) instance.
-It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage).
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$factory = new Clue\React\Ami\Factory($loop);
+$factory = new Clue\React\Ami\Factory();
 ```
+
+This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+pass the event loop instance to use for this object. You can use a `null` value
+here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+This value SHOULD NOT be given unless you're sure you want to explicitly use a
+given event loop instance.
 
 If you need custom connector settings (DNS resolution, TLS parameters, timeouts,
 proxy servers etc.), you can explicitly pass a custom instance of the
 [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
 
 ```php
-$connector = new React\Socket\Connector($loop, array(
+$connector = new React\Socket\Connector(null, array(
     'dns' => '127.0.0.1',
     'tcp' => array(
         'bindto' => '192.168.10.1:0'
@@ -125,7 +126,7 @@ $connector = new React\Socket\Connector($loop, array(
     )
 ));
 
-$factory = new Clue\React\Ami\Factory($loop, $connector);
+$factory = new Clue\React\Ami\Factory(null, $connector);
 ```
 
 #### createClient()
@@ -374,11 +375,11 @@ The resulting blocking code could look something like this:
 
 ```php
 use Clue\React\Block;
+use React\EventLoop\Loop;
 
 function getSipPeers()
 {
-    $loop = React\EventLoop\Factory::create();
-    $factory = new Clue\React\Ami\Factory($loop);
+    $factory = new Clue\React\Ami\Factory();
 
     $target = 'name:password@localhost';
     $promise = $factory->createClient($target)->then(function (Clue\React\Ami\Client $client) {
@@ -390,7 +391,7 @@ function getSipPeers()
         return $ret;
     });
 
-    return Block\await($promise, $loop, 5.0);
+    return Block\await($promise, Loop::get(), 5.0);
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "require": {
         "php": ">=5.3",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+        "react/event-loop": "^1.2",
         "react/promise": "^2.0 || ^1.1",
-        "react/socket": "^1.0 || ^0.8.2"
+        "react/socket": "^1.8"
     },
     "require-dev": {
         "clue/block-react": "^1.2",

--- a/examples/commands.php
+++ b/examples/commands.php
@@ -4,15 +4,15 @@ use Clue\React\Ami\Factory;
 use Clue\React\Ami\Client;
 use Clue\React\Ami\ActionSender;
 use Clue\React\Ami\Protocol\Response;
+use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 
 $target = isset($argv[1]) ? $argv[1] : 'name:password@localhost';
 
-$factory->createClient($target)->then(function (Client $client) use ($loop) {
+$factory->createClient($target)->then(function (Client $client) {
     echo 'Client connected. Use STDIN to send CLI commands via asterisk AMI.' . PHP_EOL;
     $sender = new ActionSender($client);
 
@@ -22,13 +22,13 @@ $factory->createClient($target)->then(function (Client $client) use ($loop) {
         echo 'Commands: ' . implode(', ', array_keys($response->getFields())) . PHP_EOL;
     });
 
-    $client->on('close', function() use ($loop) {
+    $client->on('close', function() {
         echo 'Closed' . PHP_EOL;
 
-        $loop->removeReadStream(STDIN);
+        Loop::removeReadStream(STDIN);
     });
 
-    $loop->addReadStream(STDIN, function () use ($sender) {
+    Loop::addReadStream(STDIN, function () use ($sender) {
         $line = trim(fread(STDIN, 4096));
         echo '<' . $line . PHP_EOL;
 
@@ -42,5 +42,3 @@ $factory->createClient($target)->then(function (Client $client) use ($loop) {
         );
     });
 }, 'var_dump');
-
-$loop->run();

--- a/examples/events.php
+++ b/examples/events.php
@@ -8,13 +8,12 @@ use Clue\React\Ami\Protocol\Event;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 
 $target = isset($argv[1]) ? $argv[1] : 'name:password@localhost';
 
 $factory->createClient($target)->then(
-    function (Client $client) use ($loop) {
+    function (Client $client) {
         echo 'Client connected ' . PHP_EOL;
 
         $sender = new ActionSender($client);
@@ -32,5 +31,3 @@ $factory->createClient($target)->then(
         echo 'Connection error: ' . $error;
     }
 );
-
-$loop->run();

--- a/examples/peers.php
+++ b/examples/peers.php
@@ -7,12 +7,11 @@ use Clue\React\Ami\Protocol\Collection;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 
 $target = isset($argv[1]) ? $argv[1] : 'name:password@localhost';
 
-$factory->createClient($target)->then(function (Client $client) use ($loop) {
+$factory->createClient($target)->then(function (Client $client) {
     echo 'Successfully connected' . PHP_EOL;
 
     $collector = new ActionSender($client);
@@ -24,5 +23,3 @@ $factory->createClient($target)->then(function (Client $client) use ($loop) {
         echo 'found ' . count($peers) . ' peers' . PHP_EOL;
     });
 }, 'var_dump');
-
-$loop->run();

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -9,19 +9,23 @@ use React\Socket\ConnectorInterface;
 
 /**
  * The `Factory` is responsible for creating your [`Client`](#client) instance.
- * It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage).
  *
  * ```php
- * $loop = React\EventLoop\Factory::create();
- * $factory = new Clue\React\Ami\Factory($loop);
+ * $factory = new Clue\React\Ami\Factory();
  * ```
+ *
+ * This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+ * pass the event loop instance to use for this object. You can use a `null` value
+ * here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+ * This value SHOULD NOT be given unless you're sure you want to explicitly use a
+ * given event loop instance.
  *
  * If you need custom connector settings (DNS resolution, TLS parameters, timeouts,
  * proxy servers etc.), you can explicitly pass a custom instance of the
  * [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
  *
  * ```php
- * $connector = new React\Socket\Connector($loop, array(
+ * $connector = new React\Socket\Connector(null, array(
  *     'dns' => '127.0.0.1',
  *     'tcp' => array(
  *         'bindto' => '192.168.10.1:0'
@@ -32,14 +36,14 @@ use React\Socket\ConnectorInterface;
  *     )
  * ));
  *
- * $factory = new Clue\React\Ami\Factory($loop, $connector);
+ * $factory = new Clue\React\Ami\Factory(null, $connector);
  * ```
  */
 class Factory
 {
     private $connector;
 
-    public function __construct(LoopInterface $loop, ConnectorInterface $connector = null)
+    public function __construct(LoopInterface $loop = null, ConnectorInterface $connector = null)
     {
         if ($connector === null) {
             $connector = new Connector($loop);

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -15,16 +15,14 @@ class FactoryTest extends TestCase
      */
     public function setUpFactory()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $this->tcp = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
 
-        $this->factory = new Factory($loop, $this->tcp);
+        $this->factory = new Factory(null, $this->tcp);
     }
 
     public function testDefaultCtorCreatesConnectorAutomatically()
     {
-        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
-        $this->factory = new Factory($loop);
+        $this->factory = new Factory();
 
         $ref = new \ReflectionProperty($this->factory, 'connector');
         $ref->setAccessible(true);


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

```php
// old (still supported)
$factory = new Clue\React\Ami\Factory($loop);

// new (using default loop)
$factory = new Clue\React\Ami\Factory();
```

Builds on top of https://github.com/reactphp/event-loop/pull/226, https://github.com/reactphp/event-loop/pull/229, https://github.com/reactphp/event-loop/pull/232 and and https://github.com/reactphp/socket/pull/260