### PR TITLE
Support PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.1
           - 8.0
           - 7.4
           - 7.3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # clue/reactphp-ami
 
-[![CI status](https://github.com/clue/reactphp-ami/workflows/CI/badge.svg)](https://github.com/clue/reactphp-ami/actions)
+[![CI status](https://github.com/clue/reactphp-ami/actions/workflows/ci.yml/badge.svg)](https://github.com/clue/reactphp-ami/actions)
 [![installs on Packagist](https://img.shields.io/packagist/dt/clue/ami-react?color=blue&label=installs%20on%20Packagist)](https://packagist.org/packages/clue/ami-react)
 
 Streaming, event-driven access to the Asterisk Manager Interface (AMI),

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,8 +4,9 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
+         cacheResult="false"
          colors="true"
-         cacheResult="false">
+         convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="Asterisk AMI Test Suite">
             <directory>./tests/</directory>
@@ -16,4 +17,7 @@
             <directory>./src/</directory>
         </include>
     </coverage>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
 </phpunit>


### PR DESCRIPTION
This changeset adds support for PHP 8.1 and adds `convertDeprecationsToExceptions="true"` to the `phpunit.xml` configuration to make sure we'll see future deprecation notices.

Builds on top of #67.