### PR TITLE
Update test suite and report failed assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PHPUnit:
     name: PHPUnit (PHP ${{ matrix.php }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       LOGIN: username:password@localhost
     strategy:
@@ -25,12 +25,13 @@ jobs:
           - 5.4
           - 5.3
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
-      - run: sudo apt-get -qq update || true # update package list and ignore temporary network errors
+          ini-file: development
+      - run: sudo apt-get -qq update || true && sudo apt-get install -f # update package list and ignore temporary network errors
       - run: sudo apt-get --no-install-recommends -qq install -y asterisk
       - run: sudo cp tests/username.conf /etc/asterisk/manager.d/username.conf
       - run: sudo /etc/init.d/asterisk reload

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,16 @@
     },
     "require-dev": {
         "clue/block-react": "^1.2",
-        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
     },
     "autoload": {
-        "psr-4": { "Clue\\React\\Ami\\": "src/" }
+        "psr-4": {
+            "Clue\\React\\Ami\\": "src/"
+        }
     },
     "autoload-dev": {
-        "psr-4": { "Clue\\Tests\\React\\Ami\\": "tests/" }
+        "psr-4": {
+            "Clue\\Tests\\React\\Ami\\": "tests/"
+        }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+<!-- PHPUnit configuration file with new format for PHPUnit 9.6+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          cacheResult="false"
          colors="true"
@@ -19,5 +19,10 @@
     </coverage>
     <php>
         <ini name="error_reporting" value="-1" />
+        <!-- Evaluate assertions, requires running with "php -d zend.assertions=1 vendor/bin/phpunit" -->
+        <!-- <ini name="zend.assertions" value="1" /> -->
+        <ini name="assert.active" value="1" />
+        <ini name="assert.exception" value="1" />
+        <ini name="assert.bail" value="0" />
     </php>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<!-- PHPUnit configuration file with old format for legacy PHPUnit -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
          bootstrap="vendor/autoload.php"
@@ -15,4 +15,12 @@
             <directory>./src/</directory>
         </whitelist>
     </filter>
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <!-- Evaluate assertions, requires running with "php -d zend.assertions=1 vendor/bin/phpunit" -->
+        <!-- <ini name="zend.assertions" value="1" /> -->
+        <ini name="assert.active" value="1" />
+        <ini name="assert.exception" value="1" />
+        <ini name="assert.bail" value="0" />
+    </php>
 </phpunit>


### PR DESCRIPTION
This pull request updates the test suite and will now report any failed assertions. 

I also had to add `sudo apt install -f` in order to fix some packages with unmet dependencies. I'm not quite sure what exactly is causing this (as we didn't change anything in the meantime) and I'm also not convinced if this is the right way to go about this. I invested some time into researching a proper solution but after trying out a few things, this was the only way to get the test suite green again.

If there are better options, let's use this ticket as a starting point to discuss this matter.

Builds on top of  https://github.com/clue/framework-x/pull/199, https://github.com/reactphp/socket/pull/300 and others.