### PR TITLE
Run tests on PHP 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.3
+          - 8.2
           - 8.1
           - 8.0
           - 7.4


### PR DESCRIPTION
This PR confirms PHP 8.3 support by running all tests successfully with the latest PHP version.

Builds on top of #73, #78 and others